### PR TITLE
Visitor and load balancer api controllers

### DIFF
--- a/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/MainActivity.kt
+++ b/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/MainActivity.kt
@@ -1595,6 +1595,10 @@ class MainActivity : AppCompatActivity() {
                 val assignmentResponse = apiService.requestUserAssignment(age, isDisabled)
 
                 val assignment = if (assignmentResponse != null) {
+                    // Capture the visitor ID from the response
+                    visitorId = assignmentResponse.visitorId
+                    Log.d(TAG, "Visitor ID captured from assignment: $visitorId")
+                    
                     // Convert response to UserAssignment
                     UserAssignment(
                         age = assignmentResponse.decision.age,
@@ -1641,6 +1645,11 @@ class MainActivity : AppCompatActivity() {
                 val assignmentResponse = apiService.requestUserAssignment(age, isDisabled)
 
                 val assignment = if (assignmentResponse != null) {
+                    // Capture the visitor ID from the response
+                    visitorId = assignmentResponse.visitorId
+                    Log.d(TAG, "Visitor ID captured from new assignment: $visitorId")
+                    Toast.makeText(this@MainActivity, "New visitor ID: $visitorId", Toast.LENGTH_SHORT).show()
+                    
                     // Convert response to UserAssignment
                     UserAssignment(
                         age = assignmentResponse.decision.age,

--- a/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/services/ApiService.kt
+++ b/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/services/ApiService.kt
@@ -349,12 +349,26 @@ class ApiService {
     /**
      * Assign a visitor ID via the load balancer
      */
-    suspend fun assignVisitor(): VisitorAssignment? {
+    suspend fun assignVisitor(age: Int = 30, isDisabled: Boolean = false): VisitorAssignment? {
         return withContext(Dispatchers.IO) {
             try {
+                // Create assignment request with default values
+                val assignmentRequest = AssignmentRequestSimple(
+                    age = age,
+                    isDisabled = isDisabled
+                )
+
+                val requestBody = RequestBody.create(
+                    "application/json".toMediaType(),
+                    gson.toJson(assignmentRequest)
+                )
+
+                Log.d(TAG, "Sending visitor assignment request: ${gson.toJson(assignmentRequest)}")
+
                 val request = Request.Builder()
                     .url("${ApiConstants.API_BASE_URL}${ApiConstants.Endpoints.ASSIGN_VISITOR}")
-                    .get()
+                    .post(requestBody)
+                    .addHeader("Content-Type", "application/json")
                     .build()
 
                 client.newCall(request).execute().use { response ->
@@ -365,7 +379,9 @@ class ApiService {
                             gson.fromJson(jsonString, VisitorAssignment::class.java)
                         } else null
                     } else {
-                        Log.e(TAG, "Failed to assign visitor: ${response.code}")
+                        val errorBody = response.body?.string()
+                        Log.e(TAG, "Failed to assign visitor: ${response.code} - ${response.message}")
+                        Log.e(TAG, "Error body: $errorBody")
                         null
                     }
                 }


### PR DESCRIPTION
Fixes 405 error by changing `assignVisitor` to use POST with a request body.

The `assignVisitor` method in `ApiService.kt` was incorrectly using a GET request for the `/api/LoadBalancer/arrivals/assign` endpoint, which is defined as a POST endpoint on the backend. This mismatch caused a 405 Method Not Allowed error. The change updates the method to send a POST request with the required `age` and `isDisabled` parameters in the JSON body, resolving the error and aligning with the backend API specification. Default parameters were added for backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-780f34d6-dac4-49bf-8390-92356f2415fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-780f34d6-dac4-49bf-8390-92356f2415fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

