### PR TITLE
Fix api route fetch timeout

### DIFF
--- a/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/services/ApiService.kt
+++ b/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/services/ApiService.kt
@@ -12,9 +12,14 @@ import okhttp3.MediaType.Companion.toMediaType
 import org.maplibre.geojson.FeatureCollection
 
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 class ApiService {
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
     private val gson = Gson()
     
     companion object {


### PR DESCRIPTION
Increase `OkHttpClient` timeouts to resolve `SocketTimeoutException` errors during route node fetching.

The default 10-second timeouts were insufficient for API calls to retrieve route nodes, leading to frequent `java.net.SocketTimeoutException` errors. This change configures the client with 30-second connect, read, and write timeouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e29ddb2-8c50-42c9-abdf-f52b4f4a82a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e29ddb2-8c50-42c9-abdf-f52b4f4a82a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

