### PR TITLE
Fix duplicate background layer id

### DIFF
--- a/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/MainActivity.kt
+++ b/app/src/main/java/com/KFUPM/ai_indoor_nav_mobile/MainActivity.kt
@@ -1889,7 +1889,6 @@ class MainActivity : AppCompatActivity() {
             style.addSource(source)
             
             // Add background circle layer behind text
-            val backgroundLayerId = "${transitionIndicatorsLayerId}_bg"
             val backgroundLayer = CircleLayer(backgroundLayerId, transitionIndicatorsSourceId)
                 .withProperties(
                     circleRadius(18f),


### PR DESCRIPTION
Remove duplicate `backgroundLayerId` declaration to resolve a compilation error.

The `backgroundLayerId` variable was declared twice within the same function scope, leading to a "Conflicting declarations" error. The second declaration was redundant as the variable was already in scope with the correct value.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f6282e5-2985-401d-853c-95fd71a58cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f6282e5-2985-401d-853c-95fd71a58cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

